### PR TITLE
Fix user button position

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,14 +86,14 @@ export const App = () => {
                 </Link>
               </Menu.Item>
               {user?.scopes?.includes('admin') && (
-                <Menu.Item key="/admin" disabled={!token} style={{ marginLeft: 'auto' }}>
+                <Menu.Item key="/admin" disabled={!token}>
                   <Link to="/admin">
                     Admin <ToolFilled />
                   </Link>
                 </Menu.Item>
               )}
               {!!token && !!user?.username && (
-                <Menu.Item key="/user" disabled={!token}>
+                <Menu.Item key="/user" disabled={!token} style={{ marginLeft: 'auto' }}>
                   <Dropdown overlay={<ProfileDropdown user={user} logout={logout} />}>
                     <Button type="primary">
                       {user?.username} <DownOutlined />


### PR DESCRIPTION
### Description
closes https://github.com/Clinical-Genomics/statina-ui/issues/132

Non-admin
<img width="835" alt="Screen Shot 2021-12-10 at 14 56 39" src="https://user-images.githubusercontent.com/6919697/145585126-449c5a7a-c985-4b57-8d88-309933394e26.png">

Admin
<img width="635" alt="Screen Shot 2021-12-10 at 14 56 55" src="https://user-images.githubusercontent.com/6919697/145585122-45e47eef-4658-4b1b-acde-da5b560d1ba4.png">

Since the lenght of the name changes it is hard to have the Admin menu item on the right. I moved it to the left with the other items