### PR TITLE
Add ascending default

### DIFF
--- a/src/components/ExportPDF/BatchTablePDF.tsx
+++ b/src/components/ExportPDF/BatchTablePDF.tsx
@@ -31,7 +31,7 @@ export const BatchTablePDF = ({ batchId }) => {
 
   const exportPDF = () => {
     setIsLoading(true)
-    getSamples(userContext, 0, 0, batchId, '', 'sample_id', 'descend').then(({ documents }) => {
+    getSamples(userContext, 0, 0, batchId, '', 'sample_id', 'ascend').then(({ documents }) => {
       const graph = document.getElementById(graphId)
       const unit = 'pt'
       const size = 'A4'

--- a/src/components/SamplesTable/SamplesTable.test.tsx
+++ b/src/components/SamplesTable/SamplesTable.test.tsx
@@ -116,7 +116,7 @@ test('Call to backend has correct query parameters on sort', async () => {
   )
   await waitFor(() => fireEvent.click(getByText(/Sample Name/i)))
   expect(axios.get).toHaveBeenLastCalledWith(
-    `${REACT_APP_BACKEND_URL}/samples?&page_size=10&page_num=1&batch_id=${batch}&query_string=&sort_key=sample_id&sort_direction=ascend`,
+    `${REACT_APP_BACKEND_URL}/samples?&page_size=10&page_num=1&batch_id=${batch}&query_string=&sort_key=sample_id&sort_direction=descend`,
     expect.any(Object)
   )
 })

--- a/src/components/SamplesTable/SamplesTable.tsx
+++ b/src/components/SamplesTable/SamplesTable.tsx
@@ -32,8 +32,8 @@ export const SamplesTable = ({ batchId }: SamplesProps) => {
   const [pageCount, setPageCount] = useState(0)
   const [searchValue, setSearchValue] = useState('')
   const [currentPage, setCurrentPage] = useState(1)
-  const [sortDirection, setSortDirection] = useState<'ascend' | 'descend'>()
-  const [sortKey, setSortKey] = useState<'sample_id' | 'batch_id'>()
+  const [sortDirection, setSortDirection] = useState<'ascend' | 'descend'>('ascend')
+  const [sortKey, setSortKey] = useState<string>('sample_id')
   const [isLoading, setIsLoading] = React.useState<boolean>(true)
   const [error, setError] = useState<any>()
 
@@ -138,6 +138,7 @@ export const SamplesTable = ({ batchId }: SamplesProps) => {
       dataIndex: 'sample_id',
       key: 'sample_id',
       fixed: 'left',
+      defaultSortOrder: sortDirection,
       render: (sample_id: any) => <Link to={`/samples/${sample_id}`}>{sample_id}</Link>,
       sorter: true,
     },


### PR DESCRIPTION
### Description
Adressing https://github.com/Clinical-Genomics/statina/issues/183

![Screen Shot 2021-12-15 at 15 07 22](https://user-images.githubusercontent.com/6919697/146201294-96cd50f0-9875-4063-b99d-584eed14efb9.png)

Samples now shown ascending by default