### PR TITLE
fix: use normal dataset count for negative ratio graph label

### DIFF
--- a/src/components/RatioGraph/RatioGraph.tsx
+++ b/src/components/RatioGraph/RatioGraph.tsx
@@ -27,7 +27,7 @@ const buildData = (response: RatioGraphInteface, chromosome: number): ScatterDat
       marker: {
         color: '#ccccb3',
       },
-      name: `Negative ${response?.ncv_chrom_data[chromosome].count}`,
+      name: `Negative ${response?.normal_data[chromosome].count}`,
     },
   ]
   Object.keys(response.abnormal_data[chromosome]).forEach((status) => {


### PR DESCRIPTION
### Description

### Issue number https://github.com/Clinical-Genomics/statina-ui/issues/234
