### PR TITLE
Fix statistics tab state when changing batch count

### DIFF
--- a/src/pages/Statistics/StatisticsPage.tsx
+++ b/src/pages/Statistics/StatisticsPage.tsx
@@ -12,20 +12,20 @@ export function StatisticsPage() {
   const [statistics, setStatistics] = useState<any>()
   const [selectedPlot, setSelectedPlot] = useState<string | undefined>()
   const [isLoading, setIsLoading] = React.useState<boolean>(true)
-  const [numberOfcases, setNumberOfcases] = useState<number>(20)
+  const [numberOfBatches, setNumberOfBatches] = useState<number>(20)
   const [showTotal, setShowTotal] = useState<boolean>(false)
   const defaultTabKey = 0
 
   useEffect(() => {
-    getStatistics(userContext, numberOfcases)
+    getStatistics(userContext, numberOfBatches)
       .then((response) => {
         setStatistics(response)
         setSelectedPlot((currentPlot) => currentPlot ?? response.box_plots[defaultTabKey])
-        setShowTotal(numberOfcases > response.batch_ids.length)
+        setShowTotal(numberOfBatches > response.batch_ids.length)
         setIsLoading(false)
       })
       .catch(() => setIsLoading(false))
-  }, [numberOfcases, userContext])
+  }, [numberOfBatches, userContext])
 
   const onTabChange = (key: string) => {
     setSelectedPlot(key)
@@ -33,7 +33,7 @@ export function StatisticsPage() {
 
   const onNumberOfBatchesChange = (value: number) => {
     if (value > 9) {
-      setNumberOfcases(value)
+      setNumberOfBatches(value)
     } else {
       ErrorNotification({
         type: 'error',
@@ -91,7 +91,7 @@ export function StatisticsPage() {
       <Space align="center" style={{ marginTop: '30px' }}>
         <Typography.Text>Number of batches</Typography.Text>
         <InputNumber
-          value={numberOfcases}
+          value={numberOfBatches}
           step={10}
           min={10}
           onStep={onNumberOfBatchesChange}

--- a/src/pages/Statistics/StatisticsPage.tsx
+++ b/src/pages/Statistics/StatisticsPage.tsx
@@ -20,7 +20,7 @@ export function StatisticsPage() {
     getStatistics(userContext, numberOfcases)
       .then((response) => {
         setStatistics(response)
-        setSelectedPlot(response.box_plots[defaultTabKey])
+        setSelectedPlot((currentPlot) => currentPlot ?? response.box_plots[defaultTabKey])
         setIsLoading(false)
       })
       .catch(() => setIsLoading(false))
@@ -66,7 +66,7 @@ export function StatisticsPage() {
   ) : (
     <Card>
       <Tabs
-        defaultActiveKey={defaultTabKey.toString()}
+        activeKey={selectedPlot}
         onChange={onTabChange}
         type="card"
         items={[

--- a/src/pages/Statistics/StatisticsPage.tsx
+++ b/src/pages/Statistics/StatisticsPage.tsx
@@ -17,14 +17,28 @@ export function StatisticsPage() {
   const defaultTabKey = 0
 
   useEffect(() => {
+    let ignoreResponse = false
+
     getStatistics(userContext, numberOfBatches)
       .then((response) => {
+        if (ignoreResponse) {
+          return
+        }
+
         setStatistics(response)
         setSelectedPlot((currentPlot) => currentPlot ?? response.box_plots[defaultTabKey])
         setShowTotal(numberOfBatches > response.batch_ids.length)
         setIsLoading(false)
       })
-      .catch(() => setIsLoading(false))
+      .catch(() => {
+        if (!ignoreResponse) {
+          setIsLoading(false)
+        }
+      })
+
+    return () => {
+      ignoreResponse = true
+    }
   }, [numberOfBatches, userContext])
 
   const onTabChange = (key: string) => {

--- a/src/pages/Statistics/StatisticsPage.tsx
+++ b/src/pages/Statistics/StatisticsPage.tsx
@@ -21,6 +21,7 @@ export function StatisticsPage() {
       .then((response) => {
         setStatistics(response)
         setSelectedPlot((currentPlot) => currentPlot ?? response.box_plots[defaultTabKey])
+        setShowTotal(numberOfcases > response.batch_ids.length)
         setIsLoading(false)
       })
       .catch(() => setIsLoading(false))
@@ -33,15 +34,6 @@ export function StatisticsPage() {
   const onNumberOfBatchesChange = (value: number) => {
     if (value > 9) {
       setNumberOfcases(value)
-      getStatistics(userContext, value)
-        .then((response) => {
-          setStatistics(response)
-          setIsLoading(false)
-          if (value > response.batch_ids.length) {
-            setShowTotal(true)
-          } else setShowTotal(false)
-        })
-        .catch(() => setIsLoading(false))
     } else {
       ErrorNotification({
         type: 'error',

--- a/src/pages/Statistics/StatisticsPage.tsx
+++ b/src/pages/Statistics/StatisticsPage.tsx
@@ -11,7 +11,7 @@ export function StatisticsPage() {
   const userContext = useContext(UserContext)
   const [statistics, setStatistics] = useState<any>()
   const [selectedPlot, setSelectedPlot] = useState<string | undefined>()
-  const [isLoading, setIsLoading] = React.useState<boolean>(true)
+  const [isLoading, setIsLoading] = useState<boolean>(true)
   const [numberOfBatches, setNumberOfBatches] = useState<number>(20)
   const [showTotal, setShowTotal] = useState<boolean>(false)
   const defaultTabKey = 0


### PR DESCRIPTION
**Description**
This PR fixes a Quality Control tab issue where changing the number of displayed batches could update the plotted data while leaving the previously selected tab highlighted.

Changes:
- Makes the statistics tabs controlled by `selectedPlot`.
- Preserves the selected plot when statistics are reloaded.
- Removes the duplicate statistics fetch when batch count changes.
- Updates `showTotal` from the same statistics response.
- Ignores stale statistics responses if requests finish out of order.


### Issue number https://github.com/Clinical-Genomics/statina-ui/issues/241
