### PR TITLE
Improve Quality Control plot tab labels

### DIFF
--- a/src/components/StatisticsBoxPlot/StatisticsBoxPlot.tsx
+++ b/src/components/StatisticsBoxPlot/StatisticsBoxPlot.tsx
@@ -31,9 +31,11 @@ const buildLayout = (selectedPlot: string, statistics: any, showTotal: boolean):
   const batchesWithData = getBatchesWithData(selectedPlot, statistics)
 
   return {
-    title: showTotal
-      ? `${selectedPlot} - all batches with data (${batchesWithData.length})`
-      : `${selectedPlot} - ${batchesWithData.length} most recent batches with data`,
+    title: {
+      text: showTotal
+        ? `${selectedPlot} - all batches with data (${batchesWithData.length})`
+        : `${selectedPlot} - ${batchesWithData.length} most recent batches with data`,
+    },
     hovermode: 'closest',
     margin: { b: 100 },
     height: 600,
@@ -53,7 +55,6 @@ const buildLayout = (selectedPlot: string, statistics: any, showTotal: boolean):
       showgrid: false,
       linecolor: '#636363',
       linewidth: 5,
-      title: selectedPlot,
     },
   }
 }

--- a/src/components/StatisticsScatterPlot/StatisticsScatterPlot.tsx
+++ b/src/components/StatisticsScatterPlot/StatisticsScatterPlot.tsx
@@ -23,9 +23,11 @@ const buildData = (selectedPlot: string, statistics: any): ScatterPlotData[] => 
 
 const buildLayout = (selectedPlot: string, statistics: any, showTotal: boolean): Layout => {
   return {
-    title: showTotal
-      ? `${selectedPlot} - all batches (${statistics.batch_ids.length})`
-      : `${selectedPlot} - ${statistics.batch_ids.length} most recent batches`,
+    title: {
+      text: showTotal
+        ? `${selectedPlot} - all batches (${statistics.batch_ids.length})`
+        : `${selectedPlot} - ${statistics.batch_ids.length} most recent batches`,
+    },
     hovermode: 'closest',
     margin: { b: 100 },
     height: 600,
@@ -45,7 +47,6 @@ const buildLayout = (selectedPlot: string, statistics: any, showTotal: boolean):
       showgrid: false,
       linecolor: '#636363',
       linewidth: 5,
-      title: selectedPlot,
     },
   }
 }

--- a/src/pages/Statistics/StatisticsPage.tsx
+++ b/src/pages/Statistics/StatisticsPage.tsx
@@ -7,6 +7,16 @@ import { StatisticsScatterPlot } from '@/components/StatisticsScatterPlot/Statis
 import { Loading } from '@/components/Loading'
 import { ErrorNotification } from '@/services/helpers/helpers'
 
+const statisticsTabLabels = {
+  FF_Formated: 'FFPF',
+  DuplicationRate: 'DR',
+  MappedReads: 'MR',
+  GC_Dropout: 'GCD',
+  AT_Dropout: 'ATD',
+  Bin2BinVariance: 'B2BV',
+  Library_nM: 'Lib_nM',
+}
+
 export function StatisticsPage() {
   const userContext = useContext(UserContext)
   const [statistics, setStatistics] = useState<any>()
@@ -78,7 +88,7 @@ export function StatisticsPage() {
         items={[
           ...(statistics?.box_plots ?? []).map((box) => ({
             key: box,
-            label: box,
+            label: statisticsTabLabels[box] ?? box,
             children:
               statistics && selectedPlot ? (
                 <StatisticsBoxPlot
@@ -90,7 +100,7 @@ export function StatisticsPage() {
           })),
           ...(statistics?.scatter_plots ?? []).map((scatter) => ({
             key: scatter,
-            label: scatter,
+            label: statisticsTabLabels[scatter] ?? scatter,
             children:
               statistics && selectedPlot ? (
                 <StatisticsScatterPlot

--- a/src/pages/Statistics/StatisticsPage.tsx
+++ b/src/pages/Statistics/StatisticsPage.tsx
@@ -12,20 +12,20 @@ export function StatisticsPage() {
   const [statistics, setStatistics] = useState<any>()
   const [selectedPlot, setSelectedPlot] = useState<string | undefined>()
   const [isLoading, setIsLoading] = React.useState<boolean>(true)
-  const [numberOfcases, setNumberOfcases] = useState<number>(20)
+  const [numberOfBatches, setNumberOfBatches] = useState<number>(20)
   const [showTotal, setShowTotal] = useState<boolean>(false)
   const defaultTabKey = 0
 
   useEffect(() => {
-    getStatistics(userContext, numberOfcases)
+    getStatistics(userContext, numberOfBatches)
       .then((response) => {
         setStatistics(response)
         setSelectedPlot((currentPlot) => currentPlot ?? response.box_plots[defaultTabKey])
-        setShowTotal(numberOfcases > response.batch_ids.length)
+        setShowTotal(numberOfBatches > response.batch_ids.length)
         setIsLoading(false)
       })
       .catch(() => setIsLoading(false))
-  }, [numberOfcases, userContext])
+  }, [numberOfBatches, userContext])
 
   const onTabChange = (key: string) => {
     setSelectedPlot(key)
@@ -33,7 +33,7 @@ export function StatisticsPage() {
 
   const onNumberOfBatchesChange = (value: number) => {
     if (value > 9) {
-      setNumberOfcases(value)
+      setNumberOfBatches(value)
     } else {
       ErrorNotification({
         type: 'error',
@@ -91,7 +91,7 @@ export function StatisticsPage() {
       <Space align="center" style={{ marginTop: '30px' }}>
         <Typography.Text>Number of batches</Typography.Text>
         <InputNumber
-          value={numberOfcases}
+          value={numberOfBatches}
           step={10}
           min={10}
           onStep={onNumberOfBatchesChange}

--- a/src/pages/Statistics/StatisticsPage.tsx
+++ b/src/pages/Statistics/StatisticsPage.tsx
@@ -20,7 +20,7 @@ export function StatisticsPage() {
     getStatistics(userContext, numberOfcases)
       .then((response) => {
         setStatistics(response)
-        setSelectedPlot(response.box_plots[defaultTabKey])
+        setSelectedPlot((currentPlot) => currentPlot ?? response.box_plots[defaultTabKey])
         setIsLoading(false)
       })
       .catch(() => setIsLoading(false))
@@ -66,7 +66,7 @@ export function StatisticsPage() {
   ) : (
     <Card>
       <Tabs
-        defaultActiveKey={defaultTabKey.toString()}
+        activeKey={selectedPlot}
         onChange={onTabChange}
         type="card"
         items={[

--- a/src/pages/Statistics/StatisticsPage.tsx
+++ b/src/pages/Statistics/StatisticsPage.tsx
@@ -17,14 +17,28 @@ export function StatisticsPage() {
   const defaultTabKey = 0
 
   useEffect(() => {
+    let ignoreResponse = false
+
     getStatistics(userContext, numberOfBatches)
       .then((response) => {
+        if (ignoreResponse) {
+          return
+        }
+
         setStatistics(response)
         setSelectedPlot((currentPlot) => currentPlot ?? response.box_plots[defaultTabKey])
         setShowTotal(numberOfBatches > response.batch_ids.length)
         setIsLoading(false)
       })
-      .catch(() => setIsLoading(false))
+      .catch(() => {
+        if (!ignoreResponse) {
+          setIsLoading(false)
+        }
+      })
+
+    return () => {
+      ignoreResponse = true
+    }
   }, [numberOfBatches, userContext])
 
   const onTabChange = (key: string) => {

--- a/src/pages/Statistics/StatisticsPage.tsx
+++ b/src/pages/Statistics/StatisticsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react'
-import { Tabs, Card, InputNumber, Space, Typography } from 'antd'
+import { Tabs, Card, InputNumber, Space, Tooltip, Typography } from 'antd'
 import { getStatistics } from '@/services/StatinaApi'
 import { UserContext } from '@/services/userContext'
 import { StatisticsBoxPlot } from '@/components/StatisticsBoxPlot/StatisticsBoxPlot'
@@ -88,7 +88,7 @@ export function StatisticsPage() {
         items={[
           ...(statistics?.box_plots ?? []).map((box) => ({
             key: box,
-            label: statisticsTabLabels[box] ?? box,
+            label: <Tooltip title={box}>{statisticsTabLabels[box] ?? box}</Tooltip>,
             children:
               statistics && selectedPlot ? (
                 <StatisticsBoxPlot
@@ -100,7 +100,7 @@ export function StatisticsPage() {
           })),
           ...(statistics?.scatter_plots ?? []).map((scatter) => ({
             key: scatter,
-            label: statisticsTabLabels[scatter] ?? scatter,
+            label: <Tooltip title={scatter}>{statisticsTabLabels[scatter] ?? scatter}</Tooltip>,
             children:
               statistics && selectedPlot ? (
                 <StatisticsScatterPlot

--- a/src/pages/Statistics/StatisticsPage.tsx
+++ b/src/pages/Statistics/StatisticsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react'
-import { Tabs, Card, InputNumber, Space, Tooltip, Typography } from 'antd'
+import { Tabs, Card, InputNumber, Space, Typography } from 'antd'
 import { getStatistics } from '@/services/StatinaApi'
 import { UserContext } from '@/services/userContext'
 import { StatisticsBoxPlot } from '@/components/StatisticsBoxPlot/StatisticsBoxPlot'
@@ -8,13 +8,23 @@ import { Loading } from '@/components/Loading'
 import { ErrorNotification } from '@/services/helpers/helpers'
 
 const statisticsTabLabels = {
-  FF_Formated: 'FFPF',
+  Chr13_Ratio: 'R13',
+  Chr18_Ratio: 'R18',
+  Chr21_Ratio: 'R21',
+  Chr13_Ratio_uncorrected: 'R13_unc',
+  Chr18_Ratio_uncorrected: 'R18_unc',
+  Chr21_Ratio_uncorrected: 'R21_unc',
+  FF_Formatted: 'FFPF',
+  FFY: 'FFY',
   DuplicationRate: 'DR',
   MappedReads: 'MR',
   GC_Dropout: 'GCD',
   AT_Dropout: 'ATD',
   Bin2BinVariance: 'B2BV',
   Library_nM: 'Lib_nM',
+  Stdev_13: 'SD13',
+  Stdev_18: 'SD18',
+  Stdev_21: 'SD21',
 }
 
 export function StatisticsPage() {
@@ -88,7 +98,7 @@ export function StatisticsPage() {
         items={[
           ...(statistics?.box_plots ?? []).map((box) => ({
             key: box,
-            label: <Tooltip title={box}>{statisticsTabLabels[box] ?? box}</Tooltip>,
+            label: statisticsTabLabels[box] ?? box,
             children:
               statistics && selectedPlot ? (
                 <StatisticsBoxPlot
@@ -100,7 +110,7 @@ export function StatisticsPage() {
           })),
           ...(statistics?.scatter_plots ?? []).map((scatter) => ({
             key: scatter,
-            label: <Tooltip title={scatter}>{statisticsTabLabels[scatter] ?? scatter}</Tooltip>,
+            label: statisticsTabLabels[scatter] ?? scatter,
             children:
               statistics && selectedPlot ? (
                 <StatisticsScatterPlot

--- a/src/pages/Statistics/StatisticsPage.tsx
+++ b/src/pages/Statistics/StatisticsPage.tsx
@@ -21,6 +21,7 @@ export function StatisticsPage() {
       .then((response) => {
         setStatistics(response)
         setSelectedPlot((currentPlot) => currentPlot ?? response.box_plots[defaultTabKey])
+        setShowTotal(numberOfcases > response.batch_ids.length)
         setIsLoading(false)
       })
       .catch(() => setIsLoading(false))
@@ -33,15 +34,6 @@ export function StatisticsPage() {
   const onNumberOfBatchesChange = (value: number) => {
     if (value > 9) {
       setNumberOfcases(value)
-      getStatistics(userContext, value)
-        .then((response) => {
-          setStatistics(response)
-          setIsLoading(false)
-          if (value > response.batch_ids.length) {
-            setShowTotal(true)
-          } else setShowTotal(false)
-        })
-        .catch(() => setIsLoading(false))
     } else {
       ErrorNotification({
         type: 'error',

--- a/src/pages/Statistics/StatisticsPage.tsx
+++ b/src/pages/Statistics/StatisticsPage.tsx
@@ -11,7 +11,7 @@ export function StatisticsPage() {
   const userContext = useContext(UserContext)
   const [statistics, setStatistics] = useState<any>()
   const [selectedPlot, setSelectedPlot] = useState<string | undefined>()
-  const [isLoading, setIsLoading] = React.useState<boolean>(true)
+  const [isLoading, setIsLoading] = useState<boolean>(true)
   const [numberOfBatches, setNumberOfBatches] = useState<number>(20)
   const [showTotal, setShowTotal] = useState<boolean>(false)
   const defaultTabKey = 0


### PR DESCRIPTION
**Description**
This PR improves the Quality Control statistics view by shortening long tab labels while keeping the full plot name visible in context.

Changes:
- Adds abbreviations for all statistics plot tabs.
- Keeps the full backend plot names as tab keys for data lookup.
- Fix plot title.



### Issue number https://github.com/Clinical-Genomics/statina-ui/issues/242
