### PR TITLE
Add missing axis headings in batch view

### DIFF
--- a/src/components/ChromosomesRatioPlot/ChromosomesRatioPlot.tsx
+++ b/src/components/ChromosomesRatioPlot/ChromosomesRatioPlot.tsx
@@ -45,7 +45,8 @@ const buildLayout = (statistics: any): Layout => {
       linewidth: 5,
       showgrid: true,
       gridcolor: '#bdbdbd',
-      title: 'Chromosome',
+      title: { text: 'Chromosome' },
+      automargin: true,
       tickvals: statistics.x_axis,
     },
     yaxis: {
@@ -54,7 +55,8 @@ const buildLayout = (statistics: any): Layout => {
       showgrid: false,
       linecolor: '#636363',
       linewidth: 5,
-      title: 'Coverage Ratio',
+      title: { text: 'Coverage Ratio' },
+      automargin: true,
     },
   }
 }

--- a/src/components/FetalFractionPrefaceGraph/FetalFractionPreface.tsx
+++ b/src/components/FetalFractionPrefaceGraph/FetalFractionPreface.tsx
@@ -47,7 +47,7 @@ const buildFFPFYGraphLayout = (
     height: height,
     legend: { hovermode: 'closest', orientation: 'v' },
     hovermode: 'closest',
-    title: 'Fetal fraction Y and Preface correlation.',
+    title: { text: 'Fetal fraction Y and Preface correlation.' },
     xaxis: {
       showline: true,
       zeroline: false,
@@ -105,7 +105,7 @@ const buildFFPFXGraphLayout = (
     height: height,
     legend: { hovermode: 'closest', orientation: 'v' },
     hovermode: 'closest',
-    title: 'Fetal fraction X and Preface correlation.',
+    title: { text: 'Fetal fraction X and Preface correlation.' },
     xaxis: {
       showline: true,
       zeroline: false,

--- a/src/components/FetalFractionPrefaceGraph/FetalFractionPreface.tsx
+++ b/src/components/FetalFractionPrefaceGraph/FetalFractionPreface.tsx
@@ -55,7 +55,8 @@ const buildFFPFYGraphLayout = (
       linewidth: 5,
       showgrid: false,
       gridcolor: '#bdbdbd',
-      title: 'Fetal fraction Y',
+      title: { text: 'FFY' },
+      automargin: true,
     },
     yaxis: {
       zeroline: false,
@@ -63,7 +64,8 @@ const buildFFPFYGraphLayout = (
       showgrid: false,
       linecolor: '#636363',
       linewidth: 5,
-      title: 'Fetal fraction Preface (%)',
+      title: { text: 'FFPF' },
+      automargin: true,
     },
   }
 }
@@ -111,7 +113,8 @@ const buildFFPFXGraphLayout = (
       linewidth: 5,
       showgrid: false,
       gridcolor: '#bdbdbd',
-      title: 'Fetal fraction X',
+      title: { text: 'FFX' },
+      automargin: true,
     },
     yaxis: {
       zeroline: false,
@@ -119,7 +122,8 @@ const buildFFPFXGraphLayout = (
       showgrid: false,
       linecolor: '#636363',
       linewidth: 5,
-      title: 'Fetal fraction Preface (%)',
+      title: { text: 'FFPF' },
+      automargin: true,
     },
   }
 }

--- a/src/components/FetalFractionXYGraph/FetalFractionXY.tsx
+++ b/src/components/FetalFractionXYGraph/FetalFractionXY.tsx
@@ -100,7 +100,8 @@ export const buildFFXYGraphLayout = (
       linewidth: 5,
       showgrid: false,
       gridcolor: '#bdbdbd',
-      title: 'Fetal Fraction X',
+      title: { text: 'FFX' },
+      automargin: true,
     },
     yaxis: {
       zeroline: false,
@@ -108,7 +109,8 @@ export const buildFFXYGraphLayout = (
       showgrid: false,
       linecolor: '#636363',
       linewidth: 5,
-      title: 'Fetal Fraction Y',
+      title: { text: 'FFY' },
+      automargin: true,
     },
   }
 }

--- a/src/components/FetalFractionXYGraph/FetalFractionXY.tsx
+++ b/src/components/FetalFractionXYGraph/FetalFractionXY.tsx
@@ -86,7 +86,7 @@ export const buildFFXYGraphLayout = (
 ): Layout => {
   return {
     annotations: [],
-    title: title,
+    title: title ? { text: title } : undefined,
     height: height,
     width: width,
     legend: { hovermode: 'closest', orientation: 'h' },

--- a/src/components/SamplePlot/SamplePlot.tsx
+++ b/src/components/SamplePlot/SamplePlot.tsx
@@ -59,7 +59,7 @@ const buildData = (sampleId, response): ScatterData[] => {
 
 const buildLayout = (sampleId): Layout => {
   return {
-    title: `Sample: ${sampleId}`,
+    title: { text: `Sample: ${sampleId}` },
     legend: { hovermode: 'closest' },
     height: 500,
     hovermode: 'closest',
@@ -80,7 +80,8 @@ const buildLayout = (sampleId): Layout => {
       showgrid: false,
       linecolor: '#636363',
       linewidth: 5,
-      title: 'Ratio',
+      title: { text: 'Ratio' },
+      automargin: true,
     },
   }
 }


### PR DESCRIPTION
**Description**

Adds visible axis headings to the fetal fraction plots.

**Changes**

- Updated the Fetal Fraction X/Y plot axes:
  - X-axis: `FFX`
  - Y-axis: `FFY`
- Updated the Fetal Fraction Preface plots:
  - Upper plot: X-axis `FFY`, Y-axis `FFPF`
  - Lower plot: X-axis `FFX`, Y-axis `FFPF`
- Uses Plotly’s explicit axis title format, `title: { text: ... }`, with `automargin: true` so labels render reliably and are not clipped.

<img width="1343" height="666" alt="Screenshot 2026-05-12 at 11 03 58" src="https://github.com/user-attachments/assets/4d701484-ff77-476b-9e66-0dbdfc267b77" />

<img width="1392" height="575" alt="Screenshot 2026-05-12 at 11 04 10" src="https://github.com/user-attachments/assets/88e3aeb3-9f6c-49b6-ac64-fa1ee1f5c9e1" />

<img width="1351" height="849" alt="Screenshot 2026-05-12 at 11 04 26" src="https://github.com/user-attachments/assets/9fde90bd-4f05-4846-8876-73ef5703c877" />

<img width="1187" height="816" alt="Screenshot 2026-05-12 at 11 04 44" src="https://github.com/user-attachments/assets/56c9025c-8d63-4cd6-8bf3-7846b97c0b11" />


### Issue number https://github.com/Clinical-Genomics/statina-ui/issues/245
